### PR TITLE
Add Moveable Feast weight support and warning.

### DIFF
--- a/Source/relay/Guide/Items of the Month/Pocket Professor.ash
+++ b/Source/relay/Guide/Items of the Month/Pocket Professor.ash
@@ -8,7 +8,7 @@ void IOTMPocketProfessorResource(ChecklistEntry [int] resource_entries)
 
         // Title
         int lecturesUsed = get_property_int("_pocketProfessorLectures");
-        int potentialWeight = familiar_weight($familiar[Pocket Professor]) + weight_adjustment();
+        int potentialWeight = effective_familiar_weight($familiar[Pocket Professor]) + weight_adjustment();
         int potentialWeightChip = potentialWeight - round(equipped_item($slot[familiar]).numeric_modifier('familiar weight'));
         boolean chipEquipped = lookupItem("pocket professor memory chip").have_equipped();
 
@@ -39,6 +39,9 @@ void IOTMPocketProfessorResource(ChecklistEntry [int] resource_entries)
             } else {
                 description.listAppend("Next lecture at " + chipMessage + ".");
             }
+        }
+        if (get_property("_feastedFamiliars").contains_text("Pocket Professor")) {
+            description.listAppend(HTMLGenerateSpanFont("Warning: Numbers may not be correct if Moveable Feast has expired.", "red"));
         }
 
         return ChecklistSubentryMake(main_title, subtitle, description);


### PR DESCRIPTION
Pocket Professor wasn't including moveable feast support. Mafia tracking for Moveable Feast is lacking, so the best we can do is include a warning that the numbers won't be correct once the buff has expired.